### PR TITLE
Fix bash running error

### DIFF
--- a/bin/bash/colcon_lncc
+++ b/bin/bash/colcon_lncc
@@ -3,8 +3,7 @@
 export COLCON_HOME=$PWD
 export COLCON_BUILD_PATH=$COLCON_HOME"/build"
 
-colcon_list=$(colcon list -p)
-echo $colcon_list | while read package_dir
+colcon list -p | while read package_dir
 do
   package_cmake=$package_dir"/CMakeLists.txt"
   if [ -e $package_cmake ]; then


### PR DESCRIPTION
# Problem & How to Fix
When I run the `colcon_lncc` command with bash, the command returns the error as following.
```log
./colcon_lncc: line 10: [: too many arguments
```

The reason why this error occurs is the following command returns single line.
```bash
colcon_list=$(colcon list -p)
echo $colcon_list
```
Thus, I just use following command, instead of the above.
And it worked.
```bash
colcon list -p 
```

# Environment
- ROS : melodic
```bash
$ screenfetch
                          ./+o+-       
                  yyyyy- -yyyyyy+      OS: Ubuntu 18.04 bionic
               ://+//////-yyyyyyo      Kernel: x86_64 Linux 5.3.0-62-generic
           .++ .:/++++++/-.+sss/`      Uptime: 9d 9h 58m
         .:++o:  /++++++++/:--:/-      Packages: 3820
        o:+o+:++.`..```.-/oo+++++/     Shell: bash 4.4.20
       .:+o:+o/.          `+sssoo+/    Resolution: 3840x1080
  .++/+:+oo+o:`             /sssooo.   DE: GNOME 
 /+++//+:`oo+o               /::--:.   WM: GNOME Shell
 \+/+o+++`o++o               ++////.   WM Theme: Adwaita
  .++.o+++oo+:`             /dddhhh.   GTK Theme: Ambiance [GTK2/3]
       .+.o+oo:.          `oddhhhh+    Icon Theme: ubuntu-mono-dark
        \+.++o+o``-````.:ohdhhhhh+     Font: Ubuntu 11
         `:o+++ `ohhhhhhhhyo++os:      CPU: Intel Core i7-6820HQ @ 8x 3.6GHz
           .o:`.syhhhhhhh/.oo++o`      GPU: Quadro M1000M
               /osyyyyyyo++ooo+++/     RAM: 9692MiB / 32011MiB
                   ````` +oo+++o\:    
                          `oo++.   
```

Best Regards,
